### PR TITLE
core: Fix column reference in VECMAT bounds check.

### DIFF
--- a/src-core/Spectral/VECMAT.h
+++ b/src-core/Spectral/VECMAT.h
@@ -281,21 +281,21 @@ namespace George
       delete [] mat;
     }
   inline matrix& matrix::operator=(const matrix &m)
-    {if (m.numrows != numrows || numcols != numcols)
+    {if (m.numrows != numrows || m.numcols != numcols)
         printf("error diff sizes\n");
       for(int i= 0; i< numrows; i++)
         *mat[i] = *m.mat[i];
       return *this;
     }
   inline matrix& matrix::operator+=(const matrix &m)
-    {if (m.numrows != numrows || numcols != numcols)
+    {if (m.numrows != numrows || m.numcols != numcols)
         printf("error diff sizes\n");
       for(int i= 0; i< numrows; i++)
         *mat[i] += *m.mat[i];
       return *this;
     }
   inline matrix& matrix::operator-=(const matrix &m)
-    {if (m.numrows != numrows || numcols != numcols)
+    {if (m.numrows != numrows || m.numcols != numcols)
         printf("error diff sizes\n");
       for(int i= 0; i< numrows; i++)
         *mat[i] -= *m.mat[i];


### PR DESCRIPTION
This commit fixes a compiler warning about self-comparison in a conditional.  Doesn't seem serious, since the error conditions would simply be deferred to the `vector` operators.